### PR TITLE
Change responseArr index of RefundPayment execute() to refundId

### DIFF
--- a/src/API/RefundPayment.php
+++ b/src/API/RefundPayment.php
@@ -35,7 +35,7 @@ class RefundPayment
             return false;
         }
 
-        $this->id = $responseArr['voidId'];
+        $this->id = $responseArr['refundId'];
 
         return $responseArr;
     }


### PR DESCRIPTION
Executing refunds results to `Undefined index: voidId`.

When trying to execute refunds, PayMaya Refund API returns a `refundId` index. Then `$responseArr` array accesses the wrong index `voidId`, instead of `refundId` that comes from the API's response. This results to error: 
```
Undefined index: voidId
```

This pull request fixes the response array to access the appropriate index.

EDIT: details