### PR TITLE
Bugfix/retrieve refund info missing refund id argument

### DIFF
--- a/src/Core/CheckoutAPIManager.php
+++ b/src/Core/CheckoutAPIManager.php
@@ -211,11 +211,11 @@ class CheckoutAPIManager
         return $response;
     }
 
-    public function retrieveRefundInfo($checkoutId)
+    public function retrieveRefundInfo($checkoutId, $refundId)
     {
         $this->useBasicAuthWithApiKey($this->secretApiKey);
         $httpConfig = new HTTPConfig(
-            $this->baseUrl.'/v1/checkouts/'.$checkoutId.'/refunds',
+            $this->baseUrl.'/v1/checkouts/'.$checkoutId.'/refunds/'.$refundId,
             'GET',
             $this->httpHeaders
         );


### PR DESCRIPTION
This pull request fixes the `retrieveRefundInfo()` function by adding `refundId` missing parameter and appending it to the endpoint URL.

Retrieve Refund Info should now give you one specific refund info of the specified `checkoutId` if it has any.

Closes #12.